### PR TITLE
Fix Profile sizing on nav bar & Calendar logic fixed & button styling in My Booking 

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,20 +1,28 @@
 .avatar {
   width: 40px;
+  height: 40px;
   border-radius: 50%;
+  object-fit: cover;
 }
 .avatar-large {
   width: 56px;
+  height: 56px;
   border-radius: 50%;
+  object-fit: cover;
 }
 .avatar-bordered {
   width: 40px;
+  height: 40px;
   border-radius: 50%;
   box-shadow: 1px 1px 2px rgba(0,0,0,0.4);
   border: white 1px solid;
+  object-fit: cover;
 }
 .avatar-square {
   width: 40px;
+  height: 40px;
   border-radius: 0px;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   border: white 1px solid;
+  object-fit: cover;
 }

--- a/app/assets/stylesheets/components/_container.scss
+++ b/app/assets/stylesheets/components/_container.scss
@@ -2,5 +2,5 @@
   margin-top: 65px !important;
   margin-left: 5px  !important;
   margin-right: 5px  !important;
-
+  margin-bottom: 50px !important;
 }

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,11 +1,14 @@
 .footer {
+  position: fixed;
   background: #F4F4F4;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 100px;
-  padding: 0px 50px;
+  height: 40px;
+  padding: 0px 20px;
   color: rgba(0,0,0,0.3);
+  bottom: 0;
+  width: 100%;
 }
 .footer-links {
   display: flex;

--- a/app/javascript/packs/init_flatpickr.js
+++ b/app/javascript/packs/init_flatpickr.js
@@ -6,26 +6,30 @@ function initFlatpickr()
 
   // Check that the query selector id matches the one you put around your form.
   if (startDateInput) {
-  const unavailableDates = JSON.parse(document.querySelector('#costume-booking-dates').dataset.unavailable)
-  endDateInput.disabled = true
+    const unavailableDates = JSON.parse(document.querySelector('#costume-booking-dates').dataset.unavailable)
 
-  const f = flatpickr(startDateInput, {
-    minDate: "today",
-    disable: unavailableDates,
-    dateFormat: "d-m-Y",
-  });
+    const f = flatpickr(startDateInput, {
+      minDate: "today",
+      disable: unavailableDates,
+      dateFormat: "d-m-Y",
+    });
 
-  console.log('im in the file')
-
-  startDateInput.addEventListener("change", () => {
-    if (startDateInput != "") {
-      endDateInput.disabled = false
-    }
-    flatpickr(endDateInput, {
-      minDate: f.selectedDates[0],
+    const e = flatpickr(endDateInput, {
+      minDate: "today",
       disable: unavailableDates,
       dateFormat: "d-m-Y"
-      });
+    });
+
+    endDateInput.disabled = (endDateInput.value == "")
+
+    startDateInput.addEventListener("change", (event) => {
+      if (startDateInput.value != "") {
+        endDateInput.disabled = false
+      }
+      // set the end date default date if it is blank
+      if (endDateInput.value == "" || e.selectedDates[0] < f.selectedDates[0])  e.setDate(f.selectedDates[0]);
+      // set minimum calendar selection based on start date selection
+      e.set("minDate", f.selectedDates[0]);
     })
   };
 }

--- a/app/javascript/packs/init_flatpickr.js
+++ b/app/javascript/packs/init_flatpickr.js
@@ -20,7 +20,7 @@ function initFlatpickr()
       dateFormat: "d-m-Y"
     });
 
-    endDateInput.disabled = (endDateInput.value == "")
+    endDateInput.disabled = (startDateInput.value == "")
 
     startDateInput.addEventListener("change", (event) => {
       if (startDateInput.value != "") {

--- a/app/javascript/packs/init_flatpickr.js
+++ b/app/javascript/packs/init_flatpickr.js
@@ -9,7 +9,7 @@ function initFlatpickr()
   const unavailableDates = JSON.parse(document.querySelector('#costume-booking-dates').dataset.unavailable)
   endDateInput.disabled = true
 
-  flatpickr(startDateInput, {
+  const f = flatpickr(startDateInput, {
     minDate: "today",
     disable: unavailableDates,
     dateFormat: "d-m-Y",
@@ -22,7 +22,8 @@ function initFlatpickr()
       endDateInput.disabled = false
     }
     flatpickr(endDateInput, {
-      minDate: e.target.value,
+      defaultDate: f.selectedDates[0],
+      minDate: f.selectedDates[0],
       disable: unavailableDates,
       dateFormat: "d-m-Y"
       });

--- a/app/views/bookings/edit.html.erb
+++ b/app/views/bookings/edit.html.erb
@@ -6,10 +6,10 @@
 <div id='costume-booking-dates' data-unavailable="<%= @booking.costume.unavailable_dates_edit(@booking).to_json %>">
   <%= simple_form_for([@booking]) do |f| %>
     <div class="d-flex align-items-center">
-      <%= f.input :date_start, :as => :string, :input_html => { :value => f.object.date_start.strftime("%d-%m-%Y") } %>
+      <%= f.input :date_start, :as => :string, input_html: { value: f.object.date_start.strftime("%d-%m-%Y") } %>
       <span class="ml-2"> </span>
-      <%= f.input :date_end, as: :string, type: :text, label: "To", :input_html => { :value => f.object.date_end.strftime("%d-%m-%Y") }  %>
+      <%= f.input :date_end, as: :string, type: :text, label: "To", input_html: { value: f.object.date_end.strftime("%d-%m-%Y") }  %>
     </div>
-    <%= f.submit "Update Booking Dates", class: "btn btn-primary mt-3" %>
+    <%= f.submit "Update Booking", class: "btn btn-primary mt-2" %>
   <% end %>
 </div>

--- a/app/views/bookings/edit.html.erb
+++ b/app/views/bookings/edit.html.erb
@@ -6,10 +6,10 @@
 <div id='costume-booking-dates' data-unavailable="<%= @booking.costume.unavailable_dates_edit(@booking).to_json %>">
   <%= simple_form_for([@booking]) do |f| %>
     <div class="d-flex align-items-center">
-      <%= f.input :date_start, as: :string, type: :text, label: "Book From" %>
+      <%= f.input :date_start, :as => :string, :input_html => { :value => f.object.date_start.strftime("%d-%m-%Y") } %>
       <span class="ml-2"> </span>
-      <%= f.input :date_end, as: :string, type: :text, label: "To"  %>
-      <%= f.submit "Update the booking dates", class: "btn btn-primary px-4 ml-3 mt-3" %>
+      <%= f.input :date_end, as: :string, type: :text, label: "To", :input_html => { :value => f.object.date_end.strftime("%d-%m-%Y") }  %>
     </div>
+    <%= f.submit "Update Booking Dates", class: "btn btn-primary mt-3" %>
   <% end %>
 </div>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -21,12 +21,13 @@
           <p>Start date: <%= booking.date_start.strftime("%-d %b %Y") %></p>
           <p>End date: <%= booking.date_end.strftime("%-d %b %Y")  %></p>
           <p>Price: $ <%= booking.costume.price %> per day</p>
-          <%= link_to "Edit booking", edit_booking_path(booking), :class => "link-button" %>
-          <%= link_to "Delete booking",
-            booking_path(booking),
+          <%= link_to "Edit Booking", edit_booking_path(booking), class: "mt-2 btn btn-primary" %>
+          <%= link_to booking_path(booking),
             method: :delete,
-            :class => "link-button",
-            data: { confirm: "Are you sure you want to delete this booking?" } %>
+            class: "btn btn-danger mt-2 ml-4",
+            data: { confirm: "Are you sure you want to delete this booking?" } do %>
+              <i class="far fa-trash-alt"></i>
+            <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/costumes/show.html.erb
+++ b/app/views/costumes/show.html.erb
@@ -22,7 +22,7 @@
     <% if true %>
       <%= simple_form_for([@costume, @booking]) do |f| %>
         <div class="d-flex align-items-center">
-          <%= f.input :date_start, as: :string, type: :text, label: "Book From" %>
+          <%= f.input :date_start, as: :string, type: :text, label: "Book From"%>
           <span class="ml-2"> </span>
           <%= f.input :date_end, as: :string, type: :text, label: "To"  %>
           <%= f.submit "Book", class: "btn btn-primary px-4 ml-3 mt-3" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
         <a href="#"><i class="fab fa-linkedin"></i></a>
       </div>
       <div class="footer-copyright">
-        Custumo <i class="fas fa-heart"></i>
+        Costumo <i class="fas fa-heart"></i>
       </div>
     </div>
   </body>


### PR DESCRIPTION
1. Fixed navbar profile picture to be a circle not stretched based on image size (set height and width) - no change in functionality
2. Set the bootstrap styling on buttons in my booking list, and the button on Edit Booking to next line (it's a long button) - no change in functionality
3. The biggest change of all is how the calendar behaves - changes are in edit booking html.erb and mainly in `init_flatpickr.js`.  Changes in functionalities are
     1. When **edit booking** is open, the date will now display in the correct format (code change in edit booking html ) - this code change is not required for new booking as the date are blank.  The form need to reformat the date string supplied from Rails Active Records. 
        - Secondly, the end date can now be edited before needing to change the start date first 
           (previously you need to select a start date in edit page before the end becomes enabled for selection)
        - Also, when a start date is changed to a date later than the end date , the end date is also changed to the start date.
        - by the same token the end date calendar would grey out up to until before the start date.
          This applies when you first open edit page  and when you change the start date.
     2. In New Booking form (which is in Show Costume html.erb) - just like before the end date is disable until there is a value in the start date - this restriction remains in the new booking form as it should.  
          -  Also, when a start date is selected, if the end date is blank or if the start date is later than the end date selected
        the end date is set to the start date. 
     